### PR TITLE
Add configurable OpenAI parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ Install the dependencies with:
 pip install -r requirements.txt
 ```
 
+## Configuration
+
+The scripts use the OpenAI client, which defaults to a local test server. You
+can configure the API endpoint and key using environment variables or command
+line flags.
+
+- `OPENAI_BASE_URL` – base URL of the API (default `http://localhost:5272/v1/`)
+- `OPENAI_API_KEY` – API key (default `unused`)
+
+Command line flags `--base-url` and `--api-key` override the environment
+variables.
+
+Example using environment variables:
+
+```bash
+export OPENAI_BASE_URL=http://localhost:5272/v1/
+export OPENAI_API_KEY=my-key
+python geocode.py
+```
+
+Or overriding on the command line:
+
+```bash
+python humboldt.py --base-url https://api.example.com/v1 --api-key sk-...
+```
+
 ## Scripts
 
 ### geocode.py

--- a/dd2dms.py
+++ b/dd2dms.py
@@ -3,6 +3,8 @@
 > pip install openai
 """
 import json
+import argparse
+import os
 from openai import OpenAI
 
 """
@@ -73,8 +75,21 @@ def convert_dd_to_dms(coordinates_str: str) -> str:
     return "\n".join(table)
 
 def main():
+    parser = argparse.ArgumentParser(description="DD to DMS converter")
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("OPENAI_BASE_URL", "http://localhost:5272/v1/"),
+        help="OpenAI API base URL",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("OPENAI_API_KEY", "unused"),
+        help="OpenAI API key",
+    )
+    args = parser.parse_args()
+
     # Initialize OpenAI client
-    client = OpenAI(base_url="http://localhost:5272/v1/", api_key="unused")
+    client = OpenAI(base_url=args.base_url, api_key=args.api_key)
 
     # Read user input
     user_input = input("Enter decimal-degree coordinates (newline or semicolon separated):\n")

--- a/geocode.py
+++ b/geocode.py
@@ -5,6 +5,8 @@
 """
 # Standard library imports
 import json  # to parse and format JSON for function arguments
+import argparse
+import os
 # Third-party imports
 from openai import OpenAI  # OpenAI client for LLM interaction
 from geopy.geocoders import Nominatim  # Nominatim geocoder for OpenStreetMap
@@ -71,8 +73,20 @@ def main():
       4. Execute function calls or fallback locally
       5. Display results and datum
     """
-    # Initialize OpenAI client with dummy API key
-    client = OpenAI(base_url="http://localhost:5272/v1/", api_key="unused")
+    parser = argparse.ArgumentParser(description="LLM-driven geocoder")
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("OPENAI_BASE_URL", "http://localhost:5272/v1/"),
+        help="OpenAI API base URL",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("OPENAI_API_KEY", "unused"),
+        help="OpenAI API key",
+    )
+    args = parser.parse_args()
+
+    client = OpenAI(base_url=args.base_url, api_key=args.api_key)
 
     # Prompt the user for location input
     user_input = input(

--- a/humboldt.py
+++ b/humboldt.py
@@ -3,12 +3,27 @@
 > pip install openai
 """
 import json
+import argparse
+import os
 from openai import OpenAI
 from geocode import geocode_locations  # import our geocoding tool
 from dd2dms import convert_dd_to_dms  # import DD→DMS conversion tool
 
 def main():
-    client = OpenAI(base_url="http://localhost:5272/v1/", api_key="unused")
+    parser = argparse.ArgumentParser(description="Interactive GeoAI agent")
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("OPENAI_BASE_URL", "http://localhost:5272/v1/"),
+        help="OpenAI API base URL",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("OPENAI_API_KEY", "unused"),
+        help="OpenAI API key",
+    )
+    args = parser.parse_args()
+
+    client = OpenAI(base_url=args.base_url, api_key=args.api_key)
 
     # System prompt describing the agent's role and tool‐calling instructions
     system_prompt = (


### PR DESCRIPTION
## Summary
- allow `geocode.py`, `dd2dms.py`, and `humboldt.py` to read `OPENAI_BASE_URL` and `OPENAI_API_KEY`
- expose `--base-url` and `--api-key` command-line options
- update README with configuration instructions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile geocode.py dd2dms.py humboldt.py`

------
https://chatgpt.com/codex/tasks/task_e_68781ff738ec832798390e32d744b404