### PR TITLE
Add reverse geocoding tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Humboldt> Geocode Austin, TX; Paris, France
 ```
 Humboldt will call the geocode tool and return a formatted table.
 
+You can also ask Humboldt to convert coordinates into an address:
+```
+Humboldt> Reverse geocode 40.6892,-74.0445
+```
+Humboldt will look up the nearest location and print the address.
+
 ## Extending with New Tools
 
 Future agents and tools can be added by defining function schemas in `humboldt.py` and implementing the corresponding Python functions.

--- a/humboldt.py
+++ b/humboldt.py
@@ -6,7 +6,7 @@ import json
 import argparse
 import os
 from openai import OpenAI
-from geocode import geocode_locations  # import our geocoding tool
+from geocode import geocode_locations, reverse_geocode_coordinates  # import geocoding tools
 from dd2dms import convert_dd_to_dms  # import DD→DMS conversion tool
 
 def main():
@@ -64,6 +64,20 @@ def main():
                 },
                 "required": ["coordinates"]
             }
+        },
+        {
+            "name": "reverse_geocode_coordinates",
+            "description": "Reverse geocode lat/lon pairs to addresses",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "coordinates": {
+                        "type": "string",
+                        "description": "Newline- or semicolon-delimited DD lat,lon pairs"
+                    }
+                },
+                "required": ["coordinates"]
+            }
         }
     ]
 
@@ -102,6 +116,9 @@ def main():
             elif message.function_call.name == "convert_dd_to_dms":
                 print("Status: Invoking DD to DMS conversion agent...")
                 table = convert_dd_to_dms(args["coordinates"])
+            elif message.function_call.name == "reverse_geocode_coordinates":
+                print("Status: Invoking reverse geocoding agent...")
+                table = reverse_geocode_coordinates(args["coordinates"])
             # Log tool output
             print("[DEBUG] Tool output:\n", table)
 


### PR DESCRIPTION
## Summary
- add `reverse_geocode_coordinates` to convert coordinates to an address
- expose new function in Humboldt
- document reverse geocoding usage in README
- run syntax checks

## Testing
- `python -m py_compile geocode.py humboldt.py`

------
https://chatgpt.com/codex/tasks/task_e_687925839740832794b036a7fc92a499