### PR TITLE
Add basic logging to Humboldt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ line flags.
 
 - `OPENAI_BASE_URL` – base URL of the API (default `http://localhost:5272/v1/`)
 - `OPENAI_API_KEY` – API key (default `unused`)
+- `HUMBOLDT_DEBUG` – set to `1` to enable debug logging
 
-Command line flags `--base-url` and `--api-key` override the environment
+Command line flags `--base-url`, `--api-key` and `--debug` override the environment
 variables.
 
 Example using environment variables:
@@ -37,6 +38,7 @@ Or overriding on the command line:
 ```bash
 python humboldt.py --base-url https://api.example.com/v1 --api-key sk-...
 ```
+Add `--debug` (or set `HUMBOLDT_DEBUG=1`) to enable debug output.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary
- integrate Python logging and configure with `--debug` flag
- replace debug `print` statements with `logging.debug`
- document the new environment variable and flag in the README

## Testing
- `python -m py_compile dd2dms.py geocode.py humboldt.py`

------
https://chatgpt.com/codex/tasks/task_e_687a90c547948327a4a813c55fb7912f