### PR TITLE
Add map to chat interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 openai>=1.0
 geopy>=2.0
 gradio>=3.50
+folium>=0.14
+


### PR DESCRIPTION
## Summary
- extend `webchat.py` with a map display built with folium
- update chat layout to a Blocks interface with chat and map columns
- parse geocoding results and plot markers
- add folium dependency

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687ae057563883279454592b744b44d8