### PR TITLE
Add map display in webchat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.0
 geopy>=2.0
 gradio>=3.50
+folium>=0.14


### PR DESCRIPTION
## Summary
- render a folium map in the web chat interface
- extract coordinates from geocoding and related tools
- update ChatInterface layout using Blocks
- add folium to requirements

## Testing
- `python -m py_compile webchat.py`
- `python -m py_compile geocode.py dd2dms.py humboldt.py`


------
https://chatgpt.com/codex/tasks/task_e_687b11c366588327804c93e1c586bc5e