### PR TITLE
Improve webchat layout and default map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ Keep entries concise but informative. Include the date and a brief description o
 - Switched `webchat.py` to use `gr.Chatbot(type="messages")` to avoid deprecated tuple format
 - Updated `respond` signature to accept message history as a list of dictionaries
 
+### 2025-07-19 - Webchat Layout Update
+- Moved upload and log panels into a collapsible sidebar using `gr.Accordion`
+- Added default map display on startup
+
 ---
 
 ## Guidelines for Future Development


### PR DESCRIPTION
## Summary
- refactor the webchat layout to include a collapsible sidebar
- keep upload and logs in the sidebar via an accordion
- show a default map when the interface loads
- add a devlog entry describing the changes

## Testing
- `python -m py_compile humboldt.py geocode.py dd2dms.py webchat.py file_loaders.py`
- `pip install -q -r requirements.txt`
- `python webchat.py` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_687c11bbeb7483278b499f216b19b241