### PR TITLE
Add geoBoundaries API integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ Keep entries concise but informative. Include the date and a brief description o
 ### 2025-07-19 - Landing Page Restyle
 - Redesigned index.html with a dark theme and teal accents
 - Updated buttons and feature cards for modern look
+
+### 2025-07-20 - Boundary Fetch Tool
+- Added `fetch_geo_boundaries` function to download GeoJSON from geoBoundaries API
+- Integrated new tool into Humboldt REPL and webchat with map display
+- Side panel now shows dataset table from uploads or API
+- Added `requests` dependency and updated documentation
 ---
 
 ## Guidelines for Future Development

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ AI agents for GIS and Remote Sensing workflows.
 - Python 3.8 or higher
 - geopy >=2.0
 - openai >=1.0
+- requests >=2.0
 
 Install the dependencies with:
 ```bash
@@ -78,6 +79,13 @@ You can also ask Humboldt to convert coordinates into an address:
 Humboldt> Reverse geocode 40.6892,-74.0445
 ```
 Humboldt will look up the nearest location and print the address.
+
+### Fetching Political Boundaries
+
+Humboldt can retrieve simplified boundary data from the
+[geoBoundaries](https://www.geoboundaries.org) API. Use the
+`fetch_geo_boundaries` tool with an ISO country code to download GeoJSON
+boundaries and display them on the map.
 
 ### webchat.py
 

--- a/humboldt.py
+++ b/humboldt.py
@@ -9,7 +9,12 @@ import logging
 from openai import OpenAI
 from geocode import geocode_locations, reverse_geocode_coordinates  # import geocoding tools
 from dd2dms import convert_dd_to_dms  # import DD→DMS conversion tool
-from file_loaders import load_geojson, load_kml, load_csv  # new data loading tools
+from file_loaders import (
+    load_geojson,
+    load_kml,
+    load_csv,
+    fetch_geo_boundaries,
+)
 
 def main():
     parser = argparse.ArgumentParser(description="Interactive GeoAI agent")
@@ -124,6 +129,18 @@ def main():
                 },
                 "required": ["csv"]
             }
+        },
+        {
+            "name": "fetch_geo_boundaries",
+            "description": "Download simplified political boundaries from geoBoundaries",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "iso": {"type": "string", "description": "ISO 3166-1 alpha-3 code"},
+                    "adm": {"type": "string", "description": "Administrative level", "default": "ADM0"}
+                },
+                "required": ["iso"]
+            }
         }
     ]
 
@@ -174,6 +191,9 @@ def main():
             elif message.function_call.name == "load_csv":
                 print("Status: Loading CSV data...")
                 table = load_csv(args["csv"])
+            elif message.function_call.name == "fetch_geo_boundaries":
+                print("Status: Downloading boundaries...")
+                table = fetch_geo_boundaries(args["iso"], args.get("adm", "ADM0"))
             # Log tool output
             logging.debug("Tool output:\n%s", table)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai>=1.0
 geopy>=2.0
 gradio>=3.50
 folium>=0.14
+requests>=2.0


### PR DESCRIPTION
## Summary
- support requests library in requirements
- add `fetch_geo_boundaries` for downloading GeoJSON from geoBoundaries
- allow Humboldt and webchat to call the new function
- show returned dataset in a new "Data Table" panel
- document boundary fetching usage and log the change

## Testing
- `python -m pip install -q -r requirements.txt`
- `python - <<'EOF'
from file_loaders import fetch_geo_boundaries
print(len(fetch_geo_boundaries('USA').splitlines()))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687cf19970bc83278de00ba4a7d8d40e