### PR TITLE
Shared ToolRegistry + plugin scaffolding; refactor humboldt/webchat to use registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,10 @@ Keep entries concise but informative. Include the date and a brief description o
 - Added a haversine-based distance tool with CLI helper
 - Wired distance calculations into Humboldt and the webchat UI for map display
 - Documented the new shortcut and script usage in README
+
+### 2026-02-08 - Shared Tool Registry and Plugin Scaffolding
+- Added a new `tool_registry.py` module to centralize tool schemas + handlers for both CLI and webchat.
+- Refactored `humboldt.py` and `webchat.py` to use the shared registry so tool behavior stays consistent.
+- Added plugin loading through `GEOAI_PLUGIN_MODULES` with a `register_tools(registry)` contract to make external API integrations easier.
+- Included `plugins/example_plugin.py` as a starter for adding custom API-backed tools.
+- **Technical Notes**: This follows a registry pattern similar to extensible agent frameworks; map parsing logic in webchat is now keyed by tool name.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,29 @@ When you ask Humboldt to add a marker such as "add a point for Austin, Texas," t
 
 ## Extending with New Tools
 
-Future agents and tools can be added by defining function schemas in `humboldt.py` and implementing the corresponding Python functions.
+Tools are now centralized in `tool_registry.py`, which is shared by both `humboldt.py` and `webchat.py`.
+
+### Add a built-in tool
+1. Register it in `_register_builtin_tools()` in `tool_registry.py`.
+2. Provide a JSON schema (`parameters`) and a `handler(arguments)` function.
+3. Optionally add coordinate parsing behavior in `DEFAULT_TOOL_COORD_PARSERS` if the tool returns mappable table output.
+
+### Add plugin tools (OpenCode-style extensibility)
+Set the `GEOAI_PLUGIN_MODULES` environment variable to one or more comma-delimited Python module paths.
+Each module should expose:
+
+```python
+def register_tools(registry):
+    registry.register_tool(...)
+```
+
+Example:
+```bash
+export GEOAI_PLUGIN_MODULES=plugins.example_plugin
+python humboldt.py
+```
+
+A starter module is included at `plugins/example_plugin.py`.
 
 ## Contributing
 

--- a/humboldt.py
+++ b/humboldt.py
@@ -3,14 +3,12 @@
 > pip install openai
 """
 
-import json
 import argparse
 import os
 import logging
 import subprocess
 import sys
 import importlib.util
-from typing import Any, Dict, Optional
 
 
 def check_and_install_dependencies():
@@ -132,19 +130,7 @@ def main():
     # Import modules after dependency checking
     try:
         from openai import OpenAI
-        from geocode import geocode_locations, reverse_geocode_coordinates
-        from dd2dms import convert_dd_to_dms
-        from distance import calculate_distance
-        try:
-            from file_loaders import (
-                load_geojson,
-                load_kml,
-                load_csv,
-                fetch_geo_boundaries,
-            )
-            loaders_available = True
-        except Exception:
-            loaders_available = False
+        from tool_registry import create_registry
     except ImportError as e:
         print(f"Error importing required modules: {e}")
         print("Please ensure all dependencies are installed by running:")
@@ -171,189 +157,16 @@ def main():
     )
 
     messages = [{"role": "system", "content": system_prompt}]
-    functions = [
-        {
-            "name": "geocode_locations",
-            "description": "Geocode a list of locations and return a markdown table",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "locations": {
-                        "type": "string",
-                        "description": "Newline- or semicolon-delimited list of locations to geocode",
-                    }
-                },
-                "required": ["locations"],
-            },
-        },
-        {
-            "name": "convert_dd_to_dms",
-            "description": "Convert decimal-degree coordinates to DMS table",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "coordinates": {
-                        "type": "string",
-                        "description": "Newline- or semicolon-delimited DD lat,lon pairs",
-                    }
-                },
-                "required": ["coordinates"],
-            },
-        },
-        {
-            "name": "reverse_geocode_coordinates",
-            "description": "Reverse geocode lat/lon pairs to addresses",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "coordinates": {
-                        "type": "string",
-                        "description": "Newline- or semicolon-delimited DD lat,lon pairs",
-                    }
-                },
-                "required": ["coordinates"],
-            },
-        },
-        {
-            "name": "calculate_distance",
-            "description": "Calculate great-circle distance between coordinate pairs",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "coordinates": {
-                        "type": "string",
-                        "description": "Newline- or semicolon-delimited lat1,lon1,lat2,lon2 pairs",
-                    }
-                },
-                "required": ["coordinates"],
-            },
-        },
-    ]
+    tool_registry = create_registry()
+    functions = tool_registry.openai_functions()
 
-    if 'loaders_available' in locals() and loaders_available:
-        functions.extend([
-            {
-                "name": "load_geojson",
-                "description": "Load GeoJSON text and return a coordinate table",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "geojson": {
-                            "type": "string",
-                            "description": "Contents of a GeoJSON file",
-                        }
-                    },
-                    "required": ["geojson"],
-                },
-            },
-            {
-                "name": "load_kml",
-                "description": "Load KML text and return a coordinate table",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "kml": {"type": "string", "description": "Contents of a KML file"}
-                    },
-                    "required": ["kml"],
-                },
-            },
-            {
-                "name": "load_csv",
-                "description": "Load CSV text with latitude/longitude columns",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "csv": {"type": "string", "description": "Contents of a CSV file"}
-                    },
-                    "required": ["csv"],
-                },
-            },
-            {
-                "name": "fetch_geo_boundaries",
-                "description": "Download simplified political boundaries from geoBoundaries",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "iso": {"type": "string", "description": "ISO 3166-1 alpha-3 code"},
-                        "adm": {
-                            "type": "string",
-                            "description": "Administrative level",
-                            "default": "ADM0",
-                        },
-                    },
-                    "required": ["iso"],
-                },
-            },
-        ])
-
-    # Tool registry
-    def tool_geocode_locations(arguments: Dict[str, Any]) -> str:
-        return geocode_locations(arguments.get("locations", ""))
-
-    def tool_convert_dd_to_dms(arguments: Dict[str, Any]) -> str:
-        return convert_dd_to_dms(arguments.get("coordinates", ""))
-
-    def tool_reverse_geocode_coordinates(arguments: Dict[str, Any]) -> str:
-        return reverse_geocode_coordinates(arguments.get("coordinates", ""))
-
-    def tool_calculate_distance(arguments: Dict[str, Any]) -> str:
-        return calculate_distance(arguments.get("coordinates", ""))
-
-    tool_registry: Dict[str, Any] = {
-        "geocode_locations": tool_geocode_locations,
-        "convert_dd_to_dms": tool_convert_dd_to_dms,
-        "reverse_geocode_coordinates": tool_reverse_geocode_coordinates,
-        "calculate_distance": tool_calculate_distance,
-    }
-
-    if 'loaders_available' in locals() and loaders_available:
-        def tool_load_geojson(arguments: Dict[str, Any]) -> str:
-            return load_geojson(arguments.get("geojson", ""))
-
-        def tool_load_kml(arguments: Dict[str, Any]) -> str:
-            return load_kml(arguments.get("kml", ""))
-
-        def tool_load_csv(arguments: Dict[str, Any]) -> str:
-            return load_csv(arguments.get("csv", ""))
-
-        def tool_fetch_geo_boundaries(arguments: Dict[str, Any]) -> str:
-            return fetch_geo_boundaries(arguments.get("iso", ""), arguments.get("adm", "ADM0"))
-
-        tool_registry.update({
-            "load_geojson": tool_load_geojson,
-            "load_kml": tool_load_kml,
-            "load_csv": tool_load_csv,
-            "fetch_geo_boundaries": tool_fetch_geo_boundaries,
-        })
-
-    def safe_json_loads(s: str) -> Optional[Dict[str, Any]]:
-        try:
-            return json.loads(s or "{}")
-        except Exception:
-            return None
-
-    def run_tool_call(tool_name: str, raw_args: Any) -> Optional[str]:
+    def run_tool_call(tool_name: str, raw_args):
         if args.debug:
             print(f"[DEBUG] Requested tool: {tool_name} with args: {raw_args}")
-        fn = tool_registry.get(tool_name)
-        if not fn:
+        if not tool_registry.has_tool(tool_name):
             print(f"[WARN] Unknown tool requested: {tool_name}")
             return None
-        # raw_args may already be a dict; if string try to parse JSON
-        if isinstance(raw_args, str):
-            parsed = safe_json_loads(raw_args)
-        elif isinstance(raw_args, dict):
-            parsed = raw_args
-        else:
-            parsed = {}
-        if parsed is None:
-            print("[WARN] Could not parse tool arguments; using empty args.")
-            parsed = {}
-        try:
-            return fn(parsed)
-        except Exception as e:
-            print(f"[ERROR] Tool '{tool_name}' failed: {e}")
-            return None
+        return tool_registry.invoke(tool_name, raw_args)
 
     # Greet the user
     print("Hi, I'm Humboldt, your GeoAI Agent. How can I assist you today?")
@@ -370,19 +183,19 @@ def main():
         # Direct tool invocations
         if user_input.startswith("/geocode "):
             payload = user_input[len("/geocode "):]
-            print(tool_geocode_locations({"locations": payload}))
+            print(tool_registry.invoke("geocode_locations", {"locations": payload}))
             continue
         if user_input.startswith("/reverse "):
             payload = user_input[len("/reverse "):]
-            print(tool_reverse_geocode_coordinates({"coordinates": payload}))
+            print(tool_registry.invoke("reverse_geocode_coordinates", {"coordinates": payload}))
             continue
         if user_input.startswith("/dms "):
             payload = user_input[len("/dms "):]
-            print(tool_convert_dd_to_dms({"coordinates": payload}))
+            print(tool_registry.invoke("convert_dd_to_dms", {"coordinates": payload}))
             continue
         if user_input.startswith("/distance "):
             payload = user_input[len("/distance "):]
-            print(tool_calculate_distance({"coordinates": payload}))
+            print(tool_registry.invoke("calculate_distance", {"coordinates": payload}))
             continue
 
         messages.append({"role": "user", "content": user_input})

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin package for optional GeoAI tool integrations."""

--- a/plugins/example_plugin.py
+++ b/plugins/example_plugin.py
@@ -1,0 +1,33 @@
+"""Example plugin module for GeoAI tool registration.
+
+Enable by setting:
+    export GEOAI_PLUGIN_MODULES=plugins.example_plugin
+"""
+
+
+def register_tools(registry):
+    """Register example tools with the shared registry."""
+
+    def ping_api(arguments):
+        endpoint = arguments.get("endpoint", "unknown")
+        return (
+            "| endpoint | status |\n"
+            "|---|---|\n"
+            f"| {endpoint} | plugin-ok |"
+        )
+
+    registry.register_tool(
+        name="ping_api",
+        description="Example plugin tool to demonstrate external API integration",
+        parameters={
+            "type": "object",
+            "properties": {
+                "endpoint": {
+                    "type": "string",
+                    "description": "API endpoint name or URL to test",
+                }
+            },
+            "required": ["endpoint"],
+        },
+        handler=ping_api,
+    )

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -1,0 +1,254 @@
+"""Centralized tool registry and plugin loader for GeoAI agents."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from dd2dms import convert_dd_to_dms
+from distance import calculate_distance
+from file_loaders import fetch_geo_boundaries, load_csv, load_geojson, load_kml
+from geocode import geocode_locations, reverse_geocode_coordinates
+
+
+ToolHandler = Callable[[Dict[str, Any]], str]
+
+
+@dataclass
+class ToolDefinition:
+    """Definition for an OpenAI callable tool."""
+
+    name: str
+    description: str
+    parameters: Dict[str, Any]
+    handler: ToolHandler
+
+
+class ToolRegistry:
+    """Registry for built-in and plugin tools."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, ToolDefinition] = {}
+
+    def register_tool(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        handler: ToolHandler,
+    ) -> None:
+        self._tools[name] = ToolDefinition(
+            name=name,
+            description=description,
+            parameters=parameters,
+            handler=handler,
+        )
+
+    def openai_functions(self) -> list[Dict[str, Any]]:
+        return [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            }
+            for tool in self._tools.values()
+        ]
+
+    def invoke(self, tool_name: str, raw_args: Any) -> Optional[str]:
+        tool = self._tools.get(tool_name)
+        if not tool:
+            return None
+        parsed = parse_tool_args(raw_args)
+        try:
+            return tool.handler(parsed)
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            logging.error("Tool '%s' failed: %s", tool_name, exc)
+            return f"Error running {tool_name}: {exc}"
+
+    def has_tool(self, tool_name: str) -> bool:
+        return tool_name in self._tools
+
+
+DEFAULT_TOOL_COORD_PARSERS = {
+    "geocode_locations": (2, 3),
+    "convert_dd_to_dms": (0, 1),
+    "reverse_geocode_coordinates": (0, 1),
+    "load_geojson": (0, 1),
+    "load_kml": (0, 1),
+    "load_csv": (0, 1),
+    "fetch_geo_boundaries": (0, 1),
+    "calculate_distance": "distance",
+}
+
+
+def parse_tool_args(raw_args: Any) -> Dict[str, Any]:
+    """Parse tool call args from JSON string or dict."""
+    if isinstance(raw_args, dict):
+        return raw_args
+    if isinstance(raw_args, str):
+        try:
+            parsed = json.loads(raw_args or "{}")
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def create_registry() -> ToolRegistry:
+    """Create registry with built-in tools and optional plugin tools."""
+    registry = ToolRegistry()
+    _register_builtin_tools(registry)
+    _load_plugins(registry)
+    return registry
+
+
+def _register_builtin_tools(registry: ToolRegistry) -> None:
+    registry.register_tool(
+        name="geocode_locations",
+        description="Geocode a list of locations and return a markdown table",
+        parameters={
+            "type": "object",
+            "properties": {
+                "locations": {
+                    "type": "string",
+                    "description": "Newline- or semicolon-delimited list of locations to geocode",
+                }
+            },
+            "required": ["locations"],
+        },
+        handler=lambda arguments: geocode_locations(arguments.get("locations", "")),
+    )
+    registry.register_tool(
+        name="convert_dd_to_dms",
+        description="Convert decimal-degree coordinates to DMS table",
+        parameters={
+            "type": "object",
+            "properties": {
+                "coordinates": {
+                    "type": "string",
+                    "description": "Newline- or semicolon-delimited DD lat,lon pairs",
+                }
+            },
+            "required": ["coordinates"],
+        },
+        handler=lambda arguments: convert_dd_to_dms(arguments.get("coordinates", "")),
+    )
+    registry.register_tool(
+        name="reverse_geocode_coordinates",
+        description="Reverse geocode lat/lon pairs to addresses",
+        parameters={
+            "type": "object",
+            "properties": {
+                "coordinates": {
+                    "type": "string",
+                    "description": "Newline- or semicolon-delimited DD lat,lon pairs",
+                }
+            },
+            "required": ["coordinates"],
+        },
+        handler=lambda arguments: reverse_geocode_coordinates(arguments.get("coordinates", "")),
+    )
+    registry.register_tool(
+        name="calculate_distance",
+        description="Calculate great-circle distance between coordinate pairs",
+        parameters={
+            "type": "object",
+            "properties": {
+                "coordinates": {
+                    "type": "string",
+                    "description": "Newline- or semicolon-delimited lat1,lon1,lat2,lon2 pairs",
+                }
+            },
+            "required": ["coordinates"],
+        },
+        handler=lambda arguments: calculate_distance(arguments.get("coordinates", "")),
+    )
+    registry.register_tool(
+        name="load_geojson",
+        description="Load GeoJSON text and return a coordinate table",
+        parameters={
+            "type": "object",
+            "properties": {
+                "geojson": {
+                    "type": "string",
+                    "description": "Contents of a GeoJSON file",
+                }
+            },
+            "required": ["geojson"],
+        },
+        handler=lambda arguments: load_geojson(arguments.get("geojson", "")),
+    )
+    registry.register_tool(
+        name="load_kml",
+        description="Load KML text and return a coordinate table",
+        parameters={
+            "type": "object",
+            "properties": {
+                "kml": {"type": "string", "description": "Contents of a KML file"}
+            },
+            "required": ["kml"],
+        },
+        handler=lambda arguments: load_kml(arguments.get("kml", "")),
+    )
+    registry.register_tool(
+        name="load_csv",
+        description="Load CSV text with latitude/longitude columns",
+        parameters={
+            "type": "object",
+            "properties": {
+                "csv": {"type": "string", "description": "Contents of a CSV file"}
+            },
+            "required": ["csv"],
+        },
+        handler=lambda arguments: load_csv(arguments.get("csv", "")),
+    )
+    registry.register_tool(
+        name="fetch_geo_boundaries",
+        description="Download simplified political boundaries from geoBoundaries",
+        parameters={
+            "type": "object",
+            "properties": {
+                "iso": {"type": "string", "description": "ISO 3166-1 alpha-3 code"},
+                "adm": {
+                    "type": "string",
+                    "description": "Administrative level",
+                    "default": "ADM0",
+                },
+            },
+            "required": ["iso"],
+        },
+        handler=lambda arguments: fetch_geo_boundaries(
+            arguments.get("iso", ""),
+            arguments.get("adm", "ADM0"),
+        ),
+    )
+
+
+def _load_plugins(registry: ToolRegistry) -> None:
+    """Load plugin modules from GEOAI_PLUGIN_MODULES env var.
+
+    Plugin modules should expose `register_tools(registry)`.
+    """
+    plugin_modules = os.getenv("GEOAI_PLUGIN_MODULES", "").strip()
+    if not plugin_modules:
+        return
+
+    for module_name in [m.strip() for m in plugin_modules.split(",") if m.strip()]:
+        try:
+            module = importlib.import_module(module_name)
+            register_fn = getattr(module, "register_tools", None)
+            if callable(register_fn):
+                register_fn(registry)
+                logging.info("Loaded plugin module: %s", module_name)
+            else:
+                logging.warning(
+                    "Plugin module '%s' has no callable register_tools(registry)",
+                    module_name,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logging.warning("Failed to load plugin module '%s': %s", module_name, exc)

--- a/webchat.py
+++ b/webchat.py
@@ -1,19 +1,13 @@
 import json
-import os
 import logging
+import os
 import re
-from openai import OpenAI
-import gradio as gr
+
 import folium
-from geocode import geocode_locations, reverse_geocode_coordinates
-from dd2dms import convert_dd_to_dms
-from distance import calculate_distance
-from file_loaders import (
-    load_geojson,
-    load_kml,
-    load_csv,
-    fetch_geo_boundaries,
-)
+import gradio as gr
+from openai import OpenAI
+
+from tool_registry import DEFAULT_TOOL_COORD_PARSERS, create_registry, parse_tool_args
 
 # Initialize OpenAI client using environment variables or defaults
 BASE_URL = os.getenv("OPENAI_BASE_URL", "http://localhost:5272/v1/")
@@ -94,6 +88,15 @@ def parse_distance_table(table: str) -> list[tuple[float, float]]:
     return coords
 
 
+def extract_map_coords(tool_name: str, table: str) -> list[tuple[float, float]]:
+    parser = DEFAULT_TOOL_COORD_PARSERS.get(tool_name)
+    if parser == "distance":
+        return parse_distance_table(table)
+    if isinstance(parser, tuple):
+        return parse_table_coordinates(table, parser[0], parser[1])
+    return []
+
+
 class GradioLogHandler(logging.Handler):
     """Logging handler that appends formatted records to log_history."""
 
@@ -118,118 +121,16 @@ system_prompt = (
 
 # Conversation state shared across requests
 messages = [{"role": "system", "content": system_prompt}]
+registry = create_registry()
+functions = registry.openai_functions()
 
-# Function schema for tool calls
-functions = [
-    {
-        "name": "geocode_locations",
-        "description": "Geocode a list of locations and return a markdown table",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "locations": {
-                    "type": "string",
-                    "description": "Newline- or semicolon-delimited list of locations to geocode",
-                }
-            },
-            "required": ["locations"],
-        },
-    },
-    {
-        "name": "convert_dd_to_dms",
-        "description": "Convert decimal-degree coordinates to DMS table",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "coordinates": {
-                    "type": "string",
-                    "description": "Newline- or semicolon-delimited DD lat,lon pairs",
-                }
-            },
-            "required": ["coordinates"],
-        },
-    },
-    {
-        "name": "reverse_geocode_coordinates",
-        "description": "Reverse geocode lat/lon pairs to addresses",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "coordinates": {
-                    "type": "string",
-                    "description": "Newline- or semicolon-delimited DD lat,lon pairs",
-                }
-            },
-            "required": ["coordinates"],
-        },
-    },
-    {
-        "name": "calculate_distance",
-        "description": "Calculate great-circle distance between coordinate pairs",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "coordinates": {
-                    "type": "string",
-                    "description": "Newline- or semicolon-delimited lat1,lon1,lat2,lon2 pairs",
-                }
-            },
-            "required": ["coordinates"],
-        },
-    },
-    {
-        "name": "load_geojson",
-        "description": "Load GeoJSON text and return a coordinate table",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "geojson": {
-                    "type": "string",
-                    "description": "Contents of a GeoJSON file",
-                }
-            },
-            "required": ["geojson"],
-        },
-    },
-    {
-        "name": "load_kml",
-        "description": "Load KML text and return a coordinate table",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "kml": {"type": "string", "description": "Contents of a KML file"}
-            },
-            "required": ["kml"],
-        },
-    },
-    {
-        "name": "load_csv",
-        "description": "Load CSV text with latitude/longitude columns",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "csv": {"type": "string", "description": "Contents of a CSV file"}
-            },
-            "required": ["csv"],
-        },
-    },
-    {
-        "name": "fetch_geo_boundaries",
-        "description": "Download simplified political boundaries from geoBoundaries",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "iso": {"type": "string", "description": "ISO 3166-1 alpha-3 code"},
-                "adm": {
-                    "type": "string",
-                    "description": "Administrative level",
-                    "default": "ADM0",
-                },
-            },
-            "required": ["iso"],
-        },
-    },
-]
+
+def run_tool(function_call) -> tuple[str, str]:
+    args = parse_tool_args(function_call.arguments)
+    tool_name = function_call.name
+    logging.info("Invoking %s...", tool_name)
+    table = registry.invoke(tool_name, args) or ""
+    return tool_name, table
 
 
 def respond(message: str, history: list[dict], upload_file=None):
@@ -257,49 +158,10 @@ def respond(message: str, history: list[dict], upload_file=None):
     map_html = ""
     table = ""
     if msg.function_call:
-        args = json.loads(msg.function_call.arguments)
-        if msg.function_call.name == "geocode_locations":
-            logging.info("Invoking geocode_locations...")
-            table = geocode_locations(args["locations"])
-            coords = parse_table_coordinates(table, 2, 3)
-            map_html = create_map_html(coords)
-        elif msg.function_call.name == "convert_dd_to_dms":
-            logging.info("Invoking convert_dd_to_dms...")
-            table = convert_dd_to_dms(args["coordinates"])
-            coords = parse_table_coordinates(table, 0, 1)
-            map_html = create_map_html(coords)
-        elif msg.function_call.name == "reverse_geocode_coordinates":
-            logging.info("Invoking reverse_geocode_coordinates...")
-            table = reverse_geocode_coordinates(args["coordinates"])
-            coords = parse_table_coordinates(table, 0, 1)
-            map_html = create_map_html(coords)
-        elif msg.function_call.name == "load_geojson":
-            logging.info("Invoking load_geojson...")
-            table = load_geojson(args["geojson"])
-            coords = parse_table_coordinates(table, 0, 1)
-            map_html = create_map_html(coords)
-        elif msg.function_call.name == "load_kml":
-            logging.info("Invoking load_kml...")
-            table = load_kml(args["kml"])
-            coords = parse_table_coordinates(table, 0, 1)
-            map_html = create_map_html(coords)
-        elif msg.function_call.name == "load_csv":
-            logging.info("Invoking load_csv...")
-            table = load_csv(args["csv"])
-            coords = parse_table_coordinates(table, 0, 1)
-            map_html = create_map_html(coords)
-        elif msg.function_call.name == "fetch_geo_boundaries":
-            logging.info("Invoking fetch_geo_boundaries...")
-            table = fetch_geo_boundaries(args["iso"], args.get("adm", "ADM0"))
-            coords = parse_table_coordinates(table, 0, 1)
-            map_html = create_map_html(coords)
-        elif msg.function_call.name == "calculate_distance":
-            logging.info("Invoking calculate_distance...")
-            table = calculate_distance(args["coordinates"])
-            coords = parse_distance_table(table)
-            map_html = create_map_html(coords)
-        else:
-            table = ""
+        tool_name, table = run_tool(msg.function_call)
+        coords = extract_map_coords(tool_name, table)
+        map_html = create_map_html(coords)
+
         messages.append(
             {"role": "assistant", "content": None, "function_call": msg.function_call}
         )
@@ -320,7 +182,7 @@ def respond(message: str, history: list[dict], upload_file=None):
         location = infer_location(message)
         if location:
             logging.info("Auto geocoding: %s", location)
-            table = geocode_locations(location)
+            table = registry.invoke("geocode_locations", {"locations": location}) or ""
             coords = parse_table_coordinates(table, 2, 3)
             map_html = create_map_html(coords)
             messages.append(


### PR DESCRIPTION
### Motivation
- Reduce duplicated tool schema and dispatch logic by centralizing tools in a single registry so CLI and web interfaces behave consistently.
- Make it easy to plug in external APIs and custom tools (OpenCode-style) via a simple plugin contract so integrations require minimal wiring.
- Improve maintainability and map-handling extensibility by keying coordinate parsing and map extraction by tool name.

### Description
- Added `tool_registry.py`, implementing `ToolRegistry`, `create_registry()`, built-in tool registrations, `parse_tool_args()`, `DEFAULT_TOOL_COORD_PARSERS`, and plugin loading via the `GEOAI_PLUGIN_MODULES` env var.
- Refactored `humboldt.py` to consume `create_registry()` and `openai_functions()` and to route both LLM-invoked and direct shortcut tool calls through the shared registry (`invoke`).
- Refactored `webchat.py` to use the same registry and parsing helpers, added a generic `run_tool()` path, and switched map coordinate extraction to use the registry-keyed parsers (`DEFAULT_TOOL_COORD_PARSERS`).
- Added plugin scaffolding `plugins/example_plugin.py` and `plugins/__init__.py` demonstrating the `register_tools(registry)` contract, and updated `README.md` and `AGENTS.md` with extension and plugin usage instructions.

### Testing
- Compiled the modified modules with `python -m compileall humboldt.py webchat.py tool_registry.py plugins/example_plugin.py`, which completed successfully.
- Verified plugin loading and invocation using `GEOAI_PLUGIN_MODULES=plugins.example_plugin` and a small runtime check that confirmed `ping_api` is registered and `r.invoke('ping_api', {'endpoint': 'https://example.com'})` returned the expected markdown table output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698917079164832784b1531be45abf8c)